### PR TITLE
Added visual cards

### DIFF
--- a/Assets/Card.prefab
+++ b/Assets/Card.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7801205446208702170}
   - component: {fileID: 109410727950391430}
   - component: {fileID: 7702256034400305522}
+  - component: {fileID: 3505641857223197562}
   m_Layer: 0
   m_Name: Card
   m_TagString: Untagged
@@ -101,3 +102,49 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &3505641857223197562
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4180177567904852900}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: -0.42}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 1
+  m_Size: {x: 2.6, y: 5}
+  m_EdgeRadius: 0

--- a/Assets/EncounterControl.cs
+++ b/Assets/EncounterControl.cs
@@ -18,12 +18,20 @@ public class EncounterControl : MonoBehaviour
 
     public void startEncounter(Encounter encounter){
         currEncounter = encounter;
-
-        Debug.Log(currEncounter);
-
-        CardPrefab newCard = Instantiate(cardBlueprint, new Vector2(0,0), Quaternion.identity) as CardPrefab;
-        newCard.setData(new TakeAim());
-        Debug.Log(newCard.ToString());
+        reapplyHand();
+        
     }
+
+    public void reapplyHand(){
+        for(int i = 0; i < currEncounter.hand.Count; i++){
+            CardPrefab newCard = Instantiate(cardBlueprint, cardPosition(i), Quaternion.identity) as CardPrefab;
+            newCard.setData(currEncounter.hand[i]);
+        }
+    }
+
+    public Vector2 cardPosition(int num){
+        return new Vector2((3/ (float)(currEncounter.hand.Count - 1) * (num - 1)), -4);
+    }
+
 
 }

--- a/Assets/Resources/CardArt/Take_Aim_Concept.png.meta
+++ b/Assets/Resources/CardArt/Take_Aim_Concept.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 60
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -134,7 +134,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Take_Aim_Concept_0: 272565173774975704
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Scenes/CardScripts/Bullets/SixShooterBullet.cs
+++ b/Assets/Scenes/CardScripts/Bullets/SixShooterBullet.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class SixShooterBullet : AbstractBullet
 {
-    public SixShooterBullet(): base("Six Shooter Bullet", 2, null, "The classic weapon for the classic cowboy", 1, 3){
+    public SixShooterBullet(): base("Six Shooter Bullet", 2, ImageLibrary.take_aim_concept_art, "The classic weapon for the classic cowboy", 1, 3){
 
     }
 }

--- a/Assets/Scenes/CardScripts/CardPrefab.cs
+++ b/Assets/Scenes/CardScripts/CardPrefab.cs
@@ -5,14 +5,31 @@ public class CardPrefab : MonoBehaviour
     public AbstractCard thisCard;
     public SpriteRenderer rendr;
 
+    private int originalOrder;
+
+
     public void setData(AbstractCard card){
+
         thisCard = card;
         rendr = gameObject.GetComponent<SpriteRenderer>();
-        rendr.sprite = ImageLibrary.take_aim_concept_art;
+        rendr.size += new Vector2(10f, 10f);
+
+        originalOrder = rendr.sortingOrder;
+        rendr.sprite = thisCard.IMAGE;
     }
 
     public override string ToString(){
         return thisCard.ToString();
+    }
+
+    void OnMouseEnter(){
+        gameObject.transform.position += new Vector3(0, 2, 0);
+        rendr.sortingOrder = 10;
+    }
+
+    void OnMouseExit(){
+        gameObject.transform.position -= new Vector3(0, 2, 0);
+        rendr.sortingOrder = originalOrder;
     }
 
 

--- a/Assets/Scenes/CardScripts/Skills/Defend.cs
+++ b/Assets/Scenes/CardScripts/Skills/Defend.cs
@@ -2,5 +2,5 @@ using UnityEngine;
 
 public class Defend : AbstractSkill
 {
-    public Defend(): base("Defend", 2, null, "Negate the first bullet to hit in the next three seconds."){}
+    public Defend(): base("Defend", 2, ImageLibrary.take_aim_concept_art, "Negate the first bullet to hit in the next three seconds."){}
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -244,8 +244,8 @@ Camera:
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 4
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.06461367, g: 0.21705422, b: 0.4566037, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0


### PR DESCRIPTION
At the start of the encounter, the EncounterControl now creates CardPrefabs and puts them in a visual hand. Also added code to the CardPrefab script so the card is raised and put to the front when your mouse is over it, and goes back into place when it exits.