### PR TITLE
Added mouse following to defenses

### DIFF
--- a/Assets/Managers/DefenseManager.cs
+++ b/Assets/Managers/DefenseManager.cs
@@ -17,6 +17,8 @@ public class DefenseManager : MonoBehaviour
     SpriteRenderer largeDefenseSprite;
     SpriteRenderer smallEnemyDefenseSprite;
 
+    public Camera mainCamera;
+
     
     //If the instance is the first one, it becomes the Instance.
     //Otherwise is is destroyed
@@ -85,5 +87,29 @@ public class DefenseManager : MonoBehaviour
         sprite.enabled = true;
         yield return new WaitForSeconds(num);
         sprite.enabled = false;
+    }
+
+
+    void Update(){
+        if(EncounterControl.Instance.hoveredCard != null && EncounterControl.Instance.hoveredCard.thisCard is AbstractSkill){
+            Type size = ((AbstractSkill)EncounterControl.Instance.hoveredCard.thisCard).TYPE;
+
+            if(size == Type.SmallDefend){
+                defenseFollowMouse(smallPlayerDefense);
+            }
+            else if(size == Type.MediumDefend){
+                defenseFollowMouse(mediumPlayerDefense);
+            }
+            else if(size == Type.LargeDefend){
+                defenseFollowMouse(largePlayerDefense);
+            }
+        }
+    }
+
+    void defenseFollowMouse(GameObject defense){
+        Vector3 mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+
+        defense.GetComponent<SpriteRenderer>().enabled = true;
+        defense.transform.position = new Vector3(mousePosition.x, mousePosition.y, 0);
     }
 }

--- a/Assets/Managers/EncounterControl.cs
+++ b/Assets/Managers/EncounterControl.cs
@@ -13,7 +13,7 @@ public class EncounterControl : MonoBehaviour
     public Player currPlayer;
     [SerializeField]
     private CardPrefab cardBlueprint;
-    public CardPrefab hoveredCard {private get; set;}
+    public CardPrefab hoveredCard {get; set;}
 
     //All UI elements
     public GameObject deckPlaceholder;
@@ -127,6 +127,9 @@ public class EncounterControl : MonoBehaviour
                 else{
                     position -= 1;
                 }
+            }
+            else if (Input.GetKeyDown(KeyCode.Q)){
+                BulletManager.Instance.fire(currEnemy, new SixShooterBullet());
             }
 
             //If a card is selected, the player has an action, and the user clicks Spacebar => Call the card's use() method and discard it


### PR DESCRIPTION
Added some code to the defense manager. Now, when the selected card is a Defend, you will visually see the defense sprite follow your mouse. This allow you to click the enemy bullet, when the Defend is selected, and negate it.