### PR TITLE
Changed enemy Defend behaviour

### DIFF
--- a/Assets/Managers/DefenseManager.cs
+++ b/Assets/Managers/DefenseManager.cs
@@ -17,6 +17,9 @@ public class DefenseManager : MonoBehaviour
     SpriteRenderer mediumDefenseSprite;
     SpriteRenderer largeDefenseSprite;
     SpriteRenderer smallEnemyDefenseSprite;
+
+    //Starting position of enemy defend
+    Vector3 enemySmallDefendPos;
     
     //If the instance is the first one, it becomes the Instance.
     //Otherwise is is destroyed
@@ -26,6 +29,10 @@ public class DefenseManager : MonoBehaviour
         }
         else{
             Instance = this;
+
+            //Set the default position of the enmy defense to right in front of the sprite
+            enemySmallDefendPos = new Vector3(0,0,0);
+            enemySmallDefendPos = smallEnemyDefense.transform.position;
 
             //Retrieve the SpriteRenderersw for all types of defends
             smallDefenseSprite = smallPlayerDefense.GetComponent<SpriteRenderer>();
@@ -64,6 +71,20 @@ public class DefenseManager : MonoBehaviour
     //Activate the associated Defend() method of the passed defense size, this is called by a card's use() method
     public void defend(Type size, AbstractPlayer user){
         if(user is Enemy){
+            
+            //Retrieve all bullets and set the enmy defense to the correct starting position
+            GameObject[] allBullets = GameObject.FindGameObjectsWithTag("Bullet");
+            smallEnemyDefense.transform.position = enemySmallDefendPos;
+
+            //If any bullet is a player bullet, the defend teleports to it
+            for(int i = 0; i < allBullets.Length; i++){
+                if(!(allBullets[i].GetComponent<BulletPrefab>().shooter is Enemy)){
+                    smallEnemyDefense.transform.position = allBullets[i].transform.position;
+                    break;
+                }
+            }
+
+            //Activate the defense hitbox and sprite for a short time
             smallEnemyDefense.GetComponent<PlayerDefense>().defend();
             StartCoroutine(show(0.5F, smallEnemyDefenseSprite));
         }

--- a/Assets/Managers/EncounterControl.cs
+++ b/Assets/Managers/EncounterControl.cs
@@ -44,6 +44,9 @@ public class EncounterControl : MonoBehaviour
     public bool playerTurn;
     public bool enemyTurn;
 
+    //Variable to hold if the next bullet negates enemy defends
+    private bool takeAimActive;
+
     //If the instance is the first one, it becomes the Instance.
     //Otherwise is is destroyed
     public void Awake(){
@@ -69,6 +72,8 @@ public class EncounterControl : MonoBehaviour
         enemyTurn = true;
 
         discardSpriteRenderer = discardPilePlaceholder.GetComponent<SpriteRenderer>();
+
+        takeAimActive = false;
 
         reapplyHand();
     }
@@ -161,7 +166,7 @@ public class EncounterControl : MonoBehaviour
         }
 
         //Visually show which card is selected and set hoveredCard to the currently selected card
-        if(position != -1){
+        if(position < visibleHand.Count && position >= 0){
             if(hoveredCard != null){
                 hoveredCard.deselected();
             }
@@ -202,9 +207,17 @@ public class EncounterControl : MonoBehaviour
     public void endEncounter(AbstractPlayer winner){
         setUI(false);
         Debug.Log(winner);
+
+        //Deactivate all visible cards
         GameObject[] visibleCards = GameObject.FindGameObjectsWithTag("Card");
         foreach(GameObject card in visibleCards){
             Destroy(card);
+        }
+
+        //Deactivate all visible bullets
+        GameObject[] allBullets = GameObject.FindGameObjectsWithTag("Bullet");
+        foreach(GameObject bullet in allBullets){
+            Destroy(bullet);
         }
         gameObject.SetActive(false);
     }

--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 1061892315086680403}
   m_Layer: 0
   m_Name: Bullet
-  m_TagString: Untagged
+  m_TagString: Bullet
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/BulletPrefab.cs
+++ b/Assets/Prefabs/BulletPrefab.cs
@@ -12,7 +12,7 @@ public class BulletPrefab : MonoBehaviour
     private static float feetDistance = 50F;
     private static float conversion = pixelDistance / feetDistance;
 
-    private AbstractPlayer shooter;
+    public AbstractPlayer shooter {get; private set;}
 
     //Assigns this bullet based on the passed argument.
     //Assigns the speed and bullet sprite based on bullet type (speed is negative is it is the enemy firing)

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Card
+  - Bullet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Altered the code of defend() when an Enemy plays a Defend card. Now, the DefenseManager locates the first player bullet and sets the Enemy defense position to the bullet. Then it activates the hitbox. This means that any player bullet will be blocked when the enemy plays a defend.